### PR TITLE
Fix async clock block requirements documentation

### DIFF
--- a/lib_spi/doc/rst/spi.rst
+++ b/lib_spi/doc/rst/spi.rst
@@ -188,7 +188,7 @@ the asynchronous master can output a clock at up to 100MHz
    - MOSI enabled
    - Max kbps (62.5 MHz core)
    - Max kbps (125 MHz core)
- * - 1
+ * - 2
    - x
    - x
    - 100000


### PR DESCRIPTION
The typical resource usage section of the README.rst states that the
asynchronous master uses two clock blocks, which corresponds with the
parameters for spi_master_async() as listed in the API section.