### PR TITLE
Apply skipDefaultCheckout() to the whole Jenkins pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,6 +4,9 @@ getApproval()
 
 pipeline {
   agent none
+  options {
+    skipDefaultCheckout()
+  }
   parameters {
     string(
       name: 'TOOLS_VERSION',
@@ -20,9 +23,6 @@ pipeline {
       environment {
         REPO = 'lib_spi'
         VIEW = getViewName(REPO)
-      }
-      options {
-        skipDefaultCheckout()
       }
       stages {
         stage('Get view') {


### PR DESCRIPTION
Fixes #51 - the intermittent Jenkins failure seen on lib_spi_develop.

There's a [description on the issue](https://github.com/xmos/lib_spi/issues/51#issuecomment-935681780) explaining what was happening to cause this failure.