### PR TITLE
Update Python version to 3.10.5

### DIFF
--- a/legacy_tests/spi_master_checker.py
+++ b/legacy_tests/spi_master_checker.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 XMOS LIMITED.
+# Copyright 2015-2022 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import xmostest
 
@@ -26,15 +26,15 @@ class SPIMasterChecker(xmostest.SimThread):
         sck_value = xsi.sample_port_pins(self._sck_port)
         ss_value = []
 
-	for i in range(len(self._ss_ports)):
-          ss_value.append(xsi.sample_port_pins(self._ss_ports[i]))
+        for i in range(len(self._ss_ports)):
+            ss_value.append(xsi.sample_port_pins(self._ss_ports[i]))
 
-        print "SPI Master checker started"
+        print("SPI Master checker started")
         while True:
             #first do the setup rx
             strobe_val = xsi.sample_port_pins(self._setup_strobe_port)
-	    if strobe_val == 1:
-              self.wait_for_port_pins_change([self._setup_strobe_port])
+            if strobe_val == 1:
+                self.wait_for_port_pins_change([self._setup_strobe_port])
 
             expected_cpol = self.get_setup_data(xsi, self._setup_strobe_port, self._setup_data_port)
             expected_cpha = self.get_setup_data(xsi, self._setup_strobe_port, self._setup_data_port)
@@ -50,8 +50,8 @@ class SPIMasterChecker(xmostest.SimThread):
             all_ss_deserted = True
             for i in range(len(self._ss_ports)):
                if (xsi.sample_port_pins(self._ss_ports[i]) == 0):
-		 all_ss_deserted = False
-                 break
+                   all_ss_deserted = False
+                   break
 
             while not all_ss_deserted:
               self.wait_for_port_pins_change(self._ss_ports)
@@ -101,7 +101,7 @@ class SPIMasterChecker(xmostest.SimThread):
               for i in range(len(self._ss_ports)):
                 if i != active_slave and xsi.sample_port_pins(self._ss_ports[i]) == 0:
                   error = True
-                  print "Second slave selected during first transaction"
+                  print("Second slave selected during first transaction")
 
               if (ss_value == xsi.sample_port_pins(self._ss_ports[active_slave]) and (sck_value == xsi.sample_port_pins(self._sck_port))):
                 continue
@@ -146,15 +146,15 @@ class SPIMasterChecker(xmostest.SimThread):
                       expected_rx_byte = rx_data[(rx_bit_counter/8) - 1]
                       #print "slave got {seen} and expected {expect}".format(seen=rx_byte, expect=expected_rx_byte)
                       if expected_rx_byte != rx_byte:
-                        print "ERROR: slave recieved incorrect data Got:%02x Expected:%02x"%(rx_byte, expected_rx_byte)
+                        print("ERROR: slave recieved incorrect data Got:%02x Expected:%02x"%(rx_byte, expected_rx_byte))
                         error = True
                       rx_byte = 0
               else:
                 if clock_edge_number != expected_num_bytes*2*8:
                   error = True
-                  print "ERROR: incorrect number of clock edges at slave {seen}/{expect}".format(seen=clock_edge_number, expect=expected_num_bytes*2*8)
+                  print("ERROR: incorrect number of clock edges at slave {seen}/{expect}".format(seen=clock_edge_number, expect=expected_num_bytes*2*8))
                 if error:
-                  print "Fail: CPOL:{cpol} CPHA:{cpha} KHz:{freq} MOSI Enabled:{mosi_enabled} MISO Enabled:{miso_enabled}".format(
+                  print("Fail: CPOL:{cpol} CPHA:{cpha} KHz:{freq} MOSI Enabled:{mosi_enabled} MISO Enabled:{miso_enabled}".format(
 			cpol=expected_cpol, cpha=expected_cpha,
                         mosi_enabled = expected_mosi_enabled, miso_enabled = expected_miso_enabled,
-                        freq=expected_frequency_in_khz)
+                        freq=expected_frequency_in_khz))

--- a/legacy_tests/spi_slave_checker.py
+++ b/legacy_tests/spi_slave_checker.py
@@ -1,4 +1,4 @@
-# Copyright 2015-2021 XMOS LIMITED.
+# Copyright 2015-2022 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import xmostest
 
@@ -28,12 +28,12 @@ class SPISlaveChecker(xmostest.SimThread):
         ss_value = xsi.sample_port_pins(self._ss_port)
         xsi.drive_port_pins(self._ss_port,1)
 
-        print "SPI Slave checker started"
+        print("SPI Slave checker started")
         while True:
             #first do the setup rx
             strobe_val = xsi.sample_port_pins(self._setup_strobe_port)
-	    if strobe_val == 1:
-              self.wait_for_port_pins_change([self._setup_strobe_port])
+            if strobe_val == 1:
+                self.wait_for_port_pins_change([self._setup_strobe_port])
 
             expected_cpol = self.get_setup_data(xsi, self._setup_strobe_port, self._setup_data_port)
             xsi.drive_port_pins(self._sck_port, expected_cpol)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 XMOS LIMITED.
+# Copyright 2020-2022 XMOS LIMITED.
 # This Software is subject to the terms of the XMOS Public Licence: Version 1.
 import setuptools
 
@@ -13,7 +13,7 @@ setuptools.setup(
     name='lib_spi',
     packages=setuptools.find_packages(),
     install_requires=[
-        'flake8~=3.8',
+        'flake8~=5.0',
     ],
     dependency_links=[
     ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-# python_version 3.7.6
+# python_version 3.10.5
 #
 # The parse_version_from_requirements() function in the installPipfile.groovy
 # file of the Jenkins Shared Library uses the python_version comment to set
@@ -17,7 +17,7 @@
 # pip-install this one as editable using this repository's setup.py file.  The
 # same modules should appear in the setup.py list as given below.
 
-flake8==3.8.3
+flake8==5.0.4
 
 # Development dependencies
 #


### PR DESCRIPTION
Sometimes the Jenkins job on develop fails for lib_spi because the section that runs on an agent with label `xcore.ai-explorer` can now be scheduled for sw-hw-usba-mac0 as that has an xcore.ai explorer board, but Python 3.7.6 isn't available there. Upgrading to Python 3.10.5 solves this.

I've also updated the flake8 dependency to the latest version and fixed some parentheses and indentations that are now fatal errors (these weren't fatal in Python 3.7.6).

In terms of viewfiles, lib_spi looks like it's only used by sw_vocalfusion, 3510, 3600 and 3610. Those repos don't install it from requirements.txt so I don't think this Python version and dependency change will have any effect on them.